### PR TITLE
fix(plugin): restore ai_bootstrap and harden till_post_replies install

### DIFF
--- a/plugin/ai_bootstrap/conf.json
+++ b/plugin/ai_bootstrap/conf.json
@@ -1,0 +1,10 @@
+{
+  "name": "站点启动器",
+  "brief": "补齐前置并一键启用关键插件（含 123 盘与楼中楼）",
+  "version": "0.3.0",
+  "bbs_version": "4.0.7",
+  "installed": 0,
+  "enable": 0,
+  "hooks_rank": {},
+  "dependencies": []
+}

--- a/plugin/ai_bootstrap/setting.htm
+++ b/plugin/ai_bootstrap/setting.htm
@@ -1,0 +1,108 @@
+<?php include _include(ADMIN_PATH . 'view/htm/header.inc.htm'); ?>
+
+<div class="row">
+  <div class="col-lg-12">
+    <div class="card">
+      <div class="card-body">
+        <h4 class="card-title mb-3"><?php echo $header['title']; ?></h4>
+        <p class="text-muted">
+          用于“补齐前置 + 一键启用”关键插件。主要解决：楼中楼建表失败后重装、123 盘插件前置缺失。
+        </p>
+        <p class="text-danger">
+          执行前请先备份数据库和 `plugin/` 目录。执行动作需要输入确认词 <code>ENABLE</code>。
+        </p>
+
+        <form action="<?php echo url('plugin-setting-ai_bootstrap'); ?>" method="post" id="ai_bootstrap_form">
+          <input type="hidden" name="action" id="ai_action" value="">
+
+          <div class="form-group row">
+            <label class="col-md-2 form-control-label text-md-right pr-0">确认词</label>
+            <div class="col-md-8">
+              <input type="text" class="form-control" name="confirm_word" placeholder="请输入 ENABLE">
+              <div class="figure-caption mt-2">必须输入 <code>ENABLE</code> 才会执行写操作。</div>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <div class="col-md-2"></div>
+            <div class="col-md-8">
+              <button type="button" class="btn btn-primary js-ai-action" data-action="repair_prerequisites">① 修复基础前置（菜单/主题/通知）</button>
+              <button type="button" class="btn btn-success js-ai-action ml-2" data-action="repair_pan123_stack">② 修复 123 盘与楼中楼</button>
+            </div>
+          </div>
+        </form>
+
+        <hr class="my-4">
+
+        <h5 class="mb-3">当前状态</h5>
+        <?php foreach ($state_groups as $group_name => $rows) { ?>
+        <h6 class="mt-3"><?php echo htmlspecialchars($group_name); ?></h6>
+        <div class="table-responsive mb-3">
+          <table class="table table-bordered table-sm mb-0">
+            <thead>
+              <tr>
+                <th style="width: 220px;">插件</th>
+                <th style="width: 160px;">目录</th>
+                <th style="width: 120px;">目录存在</th>
+                <th style="width: 120px;">已安装</th>
+                <th style="width: 120px;">已启用</th>
+              </tr>
+            </thead>
+            <tbody>
+              <?php foreach ($rows as $row) { ?>
+              <tr>
+                <td><?php echo htmlspecialchars($row['name']); ?></td>
+                <td><code><?php echo htmlspecialchars($row['dir']); ?></code></td>
+                <td>
+                  <?php if ($row['exists']) { ?>
+                    <span class="badge badge-success">是</span>
+                  <?php } else { ?>
+                    <span class="badge badge-danger">否</span>
+                  <?php } ?>
+                </td>
+                <td>
+                  <?php if ($row['installed']) { ?>
+                    <span class="badge badge-success">是</span>
+                  <?php } else { ?>
+                    <span class="badge badge-warning">否</span>
+                  <?php } ?>
+                </td>
+                <td>
+                  <?php if ($row['enabled']) { ?>
+                    <span class="badge badge-success">是</span>
+                  <?php } else { ?>
+                    <span class="badge badge-warning">否</span>
+                  <?php } ?>
+                </td>
+              </tr>
+              <?php } ?>
+            </tbody>
+          </table>
+        </div>
+        <?php } ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+(function () {
+  var form = document.getElementById('ai_bootstrap_form');
+  var actionInput = document.getElementById('ai_action');
+  var buttons = document.querySelectorAll('.js-ai-action');
+
+  for (var i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener('click', function () {
+      var action = this.getAttribute('data-action');
+      actionInput.value = action || '';
+      if (!actionInput.value) return;
+
+      if (!window.confirm('将执行插件安装/启用操作，是否继续？')) return;
+      form.submit();
+    });
+  }
+})();
+</script>
+
+<?php include _include(ADMIN_PATH . 'view/htm/footer.inc.htm'); ?>
+

--- a/plugin/ai_bootstrap/setting.php
+++ b/plugin/ai_bootstrap/setting.php
@@ -1,0 +1,143 @@
+<?php
+
+!defined('DEBUG') and exit('Access Denied.');
+
+$header['title'] = '站点启动器';
+
+if (!function_exists('ai_bootstrap_build_state_row')) {
+    function ai_bootstrap_build_state_row($dir)
+    {
+        global $plugins;
+
+        $exists = isset($plugins[$dir]);
+        $installed = $exists ? !empty($plugins[$dir]['installed']) : false;
+        $enabled = $exists ? !empty($plugins[$dir]['enable']) : false;
+        $name = $exists ? $plugins[$dir]['name'] : $dir;
+
+        return array(
+            'dir' => $dir,
+            'name' => $name,
+            'exists' => $exists,
+            'installed' => $installed,
+            'enabled' => $enabled,
+        );
+    }
+}
+
+if (!function_exists('ai_bootstrap_include_install_file')) {
+    function ai_bootstrap_include_install_file($dir, &$errors)
+    {
+        $install_file = APP_PATH . "plugin/$dir/install.php";
+        if (!is_file($install_file)) {
+            return;
+        }
+
+        if (function_exists('plugin_guard_try_include')) {
+            $ret = plugin_guard_try_include($install_file);
+            if (!empty($ret['code'])) {
+                $errors[] = "$dir install.php 执行失败：" . strval($ret['message']);
+            }
+            return;
+        }
+
+        include _include($install_file);
+    }
+}
+
+if (!function_exists('ai_bootstrap_install_and_enable')) {
+    function ai_bootstrap_install_and_enable($dir, &$logs, &$errors)
+    {
+        global $plugins;
+
+        if (!isset($plugins[$dir])) {
+            $errors[] = "缺少插件目录：$dir";
+            return;
+        }
+
+        $plugin_name = $plugins[$dir]['name'];
+
+        if (empty($plugins[$dir]['installed'])) {
+            $r = plugin_install($dir);
+            if (!$r) {
+                $errors[] = "安装失败：$plugin_name ($dir)";
+                return;
+            }
+
+            ai_bootstrap_include_install_file($dir, $errors);
+            if (!empty($errors)) {
+                return;
+            }
+
+            $logs[] = "已安装 $plugin_name ($dir)";
+        }
+
+        if (empty($plugins[$dir]['enable'])) {
+            $r = plugin_enable($dir);
+            if (!$r) {
+                $errors[] = "启用失败：$plugin_name ($dir)";
+                return;
+            }
+            $logs[] = "已启用 $plugin_name ($dir)";
+        }
+    }
+}
+
+$preset_groups = array(
+    '基础前置（主题/菜单/通知）' => array('abs_menu', 'abs_theme_stately', 'abs_themeacp_stately', 'huux_notice'),
+    '123 盘与楼中楼' => array('pan123_storage', 'till_post_replies'),
+);
+
+if ($method == 'POST') {
+    $action = param('action', '');
+    $confirm_word = trim(param('confirm_word', ''));
+    if ($confirm_word !== 'ENABLE') {
+        message(-1, jump('请输入 ENABLE 进行确认。', url('plugin-setting-ai_bootstrap'), 2));
+    }
+
+    $targets = array();
+    if ($action === 'repair_prerequisites') {
+        $targets = $preset_groups['基础前置（主题/菜单/通知）'];
+    } elseif ($action === 'repair_pan123_stack') {
+        // huux_notice 放在前面，避免后续插件潜在依赖未满足。
+        $targets = array('huux_notice', 'pan123_storage', 'till_post_replies');
+    } else {
+        message(-1, jump('未知操作。', url('plugin-setting-ai_bootstrap'), 2));
+    }
+
+    $logs = array();
+    $errors = array();
+
+    foreach ($targets as $dir) {
+        ai_bootstrap_install_and_enable($dir, $logs, $errors);
+    }
+
+    if (empty($errors) && function_exists('plugin_guard_compile_healthcheck')) {
+        $compile_errors = plugin_guard_compile_healthcheck();
+        if (!empty($compile_errors)) {
+            if (function_exists('plugin_guard_compile_errors_to_text')) {
+                $errors[] = "健康检查失败：\n" . plugin_guard_compile_errors_to_text($compile_errors);
+            } else {
+                $errors[] = '健康检查失败，请查看站点日志。';
+            }
+        }
+    }
+
+    $done_text = empty($logs) ? '无变更（目标插件已处于已安装+已启用状态）' : implode('；', $logs);
+    if (!empty($errors)) {
+        message(-1, jump("执行失败：\n" . implode("\n", $errors) . "\n\n已执行：$done_text", url('plugin-setting-ai_bootstrap'), 5));
+    }
+
+    message(0, jump("执行完成：$done_text", url('plugin-setting-ai_bootstrap'), 2));
+}
+
+$state_groups = array();
+foreach ($preset_groups as $group_name => $dirs) {
+    $rows = array();
+    foreach ($dirs as $dir) {
+        $rows[] = ai_bootstrap_build_state_row($dir);
+    }
+    $state_groups[$group_name] = $rows;
+}
+
+include _include(APP_PATH . 'plugin/ai_bootstrap/setting.htm');
+

--- a/plugin/till_post_replies/install.php
+++ b/plugin/till_post_replies/install.php
@@ -4,9 +4,32 @@
 
 $tablepre = $db->tablepre;
 
-$sql = "ALTER TABLE {$tablepre}post ADD COLUMN `repeat_follow` LONGTEXT NOT NULL, ADD COLUMN `r_f_c` SMALLINT(6) UNSIGNED DEFAULT 0 NOT NULL, ADD COLUMN `r_f_a` SMALLINT(6) UNSIGNED DEFAULT 0 NOT NULL";
-$r = db_exec($sql);
-$r === FALSE and message(-1, '创建表结构失败');
+if (!function_exists('till_post_replies_column_exists')) {
+	function till_post_replies_column_exists($table, $column)
+	{
+		$r = db_sql_find_one("SHOW COLUMNS FROM `$table` LIKE '$column'");
+		return !empty($r);
+	}
+}
+
+$post_table = $tablepre . 'post';
+$alter_parts = array();
+
+if (!till_post_replies_column_exists($post_table, 'repeat_follow')) {
+	$alter_parts[] = "ADD COLUMN `repeat_follow` LONGTEXT NOT NULL";
+}
+if (!till_post_replies_column_exists($post_table, 'r_f_c')) {
+	$alter_parts[] = "ADD COLUMN `r_f_c` SMALLINT(6) UNSIGNED NOT NULL DEFAULT 0";
+}
+if (!till_post_replies_column_exists($post_table, 'r_f_a')) {
+	$alter_parts[] = "ADD COLUMN `r_f_a` SMALLINT(6) UNSIGNED NOT NULL DEFAULT 0";
+}
+
+if (!empty($alter_parts)) {
+	$sql = "ALTER TABLE `$post_table` " . implode(', ', $alter_parts);
+	$r = db_exec($sql);
+	$r === FALSE and message(-1, '创建表结构失败');
+}
 
 $setting = setting_get('till_post_replies_setting');
 if (empty($setting)) {


### PR DESCRIPTION
## Summary
- Add back a minimal `ai_bootstrap` plugin to repair missing prerequisite stacks from admin UI.
- Make `till_post_replies` install migration idempotent by checking columns before `ALTER TABLE`.
- Prevent repeated-install failures where existing columns previously caused immediate install abort.

## Test plan
- [ ] In admin plugin page, install/enable `ai_bootstrap` and run both repair actions with confirm word `ENABLE`.
- [ ] Reinstall `till_post_replies` on a database where some/all target columns already exist, verify no "??????????? error.
- [ ] Install `pan123_storage` after prerequisite repair and verify no missing-dependency blocking.
- [ ] Smoke test thread pages to confirm nested replies load and post correctly.
