### PR TITLE
fix(theme): align create and moderation buttons

### DIFF
--- a/plugin/abs_theme_stately/hook/widget_btn_create_thread.htm
+++ b/plugin/abs_theme_stately/hook/widget_btn_create_thread.htm
@@ -1,4 +1,4 @@
-<a role="button" class="btn btn-primary btn-lg bg-gradient btn-block mb-3" href="<?= url('thread-create-' . $fid); ?>">
-    <i class="las la-edit fs-5"></i>
-    <?= lang('thread_create_new'); ?>
+<a role="button" class="btn btn-primary btn-lg bg-gradient w-100 d-flex align-items-center justify-content-center mb-3" href="<?= url('thread-create-' . $fid); ?>">
+    <i class="las la-edit fs-5 me-1"></i>
+    <span><?= lang('thread_create_new'); ?></span>
 </a>

--- a/plugin/abs_theme_stately/overwrite/view/htm/thread_list_mod.inc.htm
+++ b/plugin/abs_theme_stately/overwrite/view/htm/thread_list_mod.inc.htm
@@ -1,33 +1,31 @@
 <?php if($gid > 0 && $gid < 5) : ?>
 <div class="mt-2 mb-5">
-	<div class="input-group justify-content-center mod-button">
+	<div class="mod-button d-flex flex-wrap align-items-center justify-content-center">
 		<?php if(param(0) != 'thread') : ?>
-		<span class="input-group-text">
-			<span class="form-check">
-				<input type="checkbox" data-target='input[name="modtid"]' class="form-check-input checkall mt-2 mr-2" value="" aria-label="<?= lang('checkall');?>" id="mod_checkall" />
-				<label class="form-check-label" for="mod_checkall">
-					<?= lang('checkall');?>
-				</label>
-			</span>
-		</span>
+		<label class="mod-checkall" for="mod_checkall">
+			<input type="checkbox" data-target='input[name="modtid"]' class="form-check-input checkall" value="" aria-label="<?= lang('checkall');?>" id="mod_checkall" />
+			<span><?= lang('checkall');?></span>
+		</label>
 		<?php endif; ?>
-		<!--{hook thread_list_mod_delete_before.htm}-->
-		<button class="btn btn-danger delete" data-modal-url="<?= url('mod-delete');?>" data-modal-title="<?= lang('delete');?>" data-modal-arg=".threadlist" data-modal-size="md">
-			<?= lang('delete');?>
-		</button>
-		<!--{hook thread_list_mod_delete_after.htm}-->
-		<button class="btn btn-secondary move" data-modal-url="<?= url('mod-move');?>" data-modal-title="<?= lang('move');?>" data-modal-arg=".threadlist" data-modal-size="md">
-			<?= lang('move');?>
-		</button>
-		<!--{hook thread_list_mod_top_before.htm}-->
-		<button class="btn btn-secondary top" data-modal-url="<?= url('mod-top');?>" data-modal-title="<?= lang('top');?>" data-modal-arg=".threadlist" data-modal-size="md">
-			<?= lang('top');?>
-		</button>
-		<!--{hook thread_list_mod_top_after.htm}-->
-		<button class="btn btn-secondary _close" data-modal-url="<?= url('mod-close');?>" data-modal-title="<?= lang('close');?>" data-modal-arg=".threadlist" data-modal-size="md">
-			<?= lang('close');?>
-		</button>
-		<!--{hook thread_list_mod_close_after.htm}-->
+		<div class="btn-group" role="group" aria-label="moderation actions">
+			<!--{hook thread_list_mod_delete_before.htm}-->
+			<button class="btn btn-danger delete" data-modal-url="<?= url('mod-delete');?>" data-modal-title="<?= lang('delete');?>" data-modal-arg=".threadlist" data-modal-size="md">
+				<?= lang('delete');?>
+			</button>
+			<!--{hook thread_list_mod_delete_after.htm}-->
+			<button class="btn btn-secondary move" data-modal-url="<?= url('mod-move');?>" data-modal-title="<?= lang('move');?>" data-modal-arg=".threadlist" data-modal-size="md">
+				<?= lang('move');?>
+			</button>
+			<!--{hook thread_list_mod_top_before.htm}-->
+			<button class="btn btn-secondary top" data-modal-url="<?= url('mod-top');?>" data-modal-title="<?= lang('top');?>" data-modal-arg=".threadlist" data-modal-size="md">
+				<?= lang('top');?>
+			</button>
+			<!--{hook thread_list_mod_top_after.htm}-->
+			<button class="btn btn-secondary _close" data-modal-url="<?= url('mod-close');?>" data-modal-title="<?= lang('close');?>" data-modal-arg=".threadlist" data-modal-size="md">
+				<?= lang('close');?>
+			</button>
+			<!--{hook thread_list_mod_close_after.htm}-->
+		</div>
 	</div>
 </div>
 <?php endif; ?>

--- a/plugin/abs_theme_stately/overwrite/wellcms/thread_list_mod.inc.htm
+++ b/plugin/abs_theme_stately/overwrite/wellcms/thread_list_mod.inc.htm
@@ -1,21 +1,23 @@
 <?php if($gid > 0 && $gid < 5) { ?>
 <div class="text-center">
-	<?php if(param(0) != 'thread') { ?>
-	<label class="mr-3">
-		<input type="checkbox" data-target='input[name="modtid"]' class="checkall mt-2 mr-2" value="" aria-label="<?php echo lang('checkall');?>" /><?php echo lang('checkall');?>
-	</label>
-	<?php } ?>
-	
-	<div class="btn-group mod-button my-3" role="group" aria-label="">
-		<!--{hook website_list_mod_delete_before.htm}-->
-		<button class="btn btn-secondary delete" data-modal-url="<?php echo url('mode-delete', $extra);?>" data-modal-title="<?php echo lang('delete');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('delete');?></button>
-		<!--{hook website_list_mod_delete_after.htm}-->
-		<button class="btn btn-secondary move" data-modal-url="<?php echo url('mode-move', $extra);?>" data-modal-title="<?php echo lang('move');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('move');?></button>
-		<!--{hook website_list_mod_top_before.htm}-->
-		<button class="btn btn-secondary top" data-modal-url="<?php echo url('mode-top', $extra);?>" data-modal-title="<?php echo lang('top');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('top');?></button>
-		<!--{hook website_list_mod_top_after.htm}-->
-		<button class="btn btn-secondary _close" data-modal-url="<?php echo url('mode-close', $extra);?>" data-modal-title="<?php echo lang('close');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('close');?></button>
-		<!--{hook website_list_mod_close_after.htm}-->
+	<div class="mod-button d-flex flex-wrap align-items-center justify-content-center my-3">
+		<?php if(param(0) != 'thread') { ?>
+		<label class="mod-checkall">
+			<input type="checkbox" data-target='input[name="modtid"]' class="form-check-input checkall" value="" aria-label="<?php echo lang('checkall');?>" />
+			<span><?php echo lang('checkall');?></span>
+		</label>
+		<?php } ?>
+		<div class="btn-group" role="group" aria-label="moderation actions">
+			<!--{hook website_list_mod_delete_before.htm}-->
+			<button class="btn btn-secondary delete" data-modal-url="<?php echo url('mode-delete', $extra);?>" data-modal-title="<?php echo lang('delete');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('delete');?></button>
+			<!--{hook website_list_mod_delete_after.htm}-->
+			<button class="btn btn-secondary move" data-modal-url="<?php echo url('mode-move', $extra);?>" data-modal-title="<?php echo lang('move');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('move');?></button>
+			<!--{hook website_list_mod_top_before.htm}-->
+			<button class="btn btn-secondary top" data-modal-url="<?php echo url('mode-top', $extra);?>" data-modal-title="<?php echo lang('top');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('top');?></button>
+			<!--{hook website_list_mod_top_after.htm}-->
+			<button class="btn btn-secondary _close" data-modal-url="<?php echo url('mode-close', $extra);?>" data-modal-title="<?php echo lang('close');?>" data-modal-arg=".threadlist" data-modal-size="md"><?php echo lang('close');?></button>
+			<!--{hook website_list_mod_close_after.htm}-->
+		</div>
 	</div>
 </div>
 <?php } ?>

--- a/plugin/abs_theme_stately/view/css/bbs.css
+++ b/plugin/abs_theme_stately/view/css/bbs.css
@@ -2361,6 +2361,47 @@ table.card-header .nav-item>a.active {
     color: var(--bs-primary);
 }
 
+.mod-button {
+    gap: 0.75rem;
+}
+
+.mod-button .mod-checkall {
+    display: inline-flex;
+    align-items: center;
+    margin: 0;
+    padding: 0.625rem 0.875rem;
+    border: 1px solid rgba(67, 89, 113, 0.18);
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.72);
+    line-height: 1;
+}
+
+.dark-style .mod-button .mod-checkall {
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.mod-button .mod-checkall .form-check-input {
+    margin: 0 0.5rem 0 0;
+}
+
+.mod-button .btn-group {
+    display: inline-flex;
+}
+
+.mod-button .btn {
+    white-space: nowrap;
+}
+
+@media (max-width:575.98px) {
+    .mod-button .btn-group {
+        width: 100%;
+    }
+
+    .mod-button .btn-group .btn {
+        flex: 1 1 auto;
+    }
+}
+
 .user-profile-header .btn.btn-block {
     display: inline-block;
     width: fit-content;


### PR DESCRIPTION
## Summary
- make the sidebar thread-create button use an explicit full-width flex layout so it stays aligned in the right rail
- replace the thread moderation `input-group` with a flex + `btn-group` toolbar in both Xiuno and WellCMS thread lists
- add compact theme CSS for the check-all chip spacing and mobile button grouping

## Test plan
- [x] Review the source diff for homepage/forum/WellCMS thread-list templates and shared theme CSS
- [x] Run `powershell -ExecutionPolicy Bypass -File .\devkit\release\build-vps-test-release.ps1`
- [ ] Open homepage/forum/WellCMS list pages and visually verify alignment in a running environment