### PR TITLE
fix: PHP 8.2 compat for hexToHsl + nginx deploy guide for Stately

### DIFF
--- a/docs/TEST_VPS_DEPLOY.md
+++ b/docs/TEST_VPS_DEPLOY.md
@@ -46,7 +46,51 @@ powershell -ExecutionPolicy Bypass -File .\devkit\release\build-vps-test-release
    - `log/`
 5. 浏览器访问站点，完成 Xiuno 安装向导。
 6. 安装完成后删除 `install/` 目录（安全要求）。
-7. 配置 Nginx/Apache 伪静态（Xiuno 必需）。
+7. 配置 Nginx/Apache 伪静态（Xiuno 必需），参考下方 Nginx 配置示例。
+
+### Nginx 伪静态配置要点
+
+Stately 主题会将合并后的 CSS/JS 输出到 `tmp/` 目录（如 `tmp/stately_h.min.css`）。
+默认的安全规则 `deny all` 会阻止浏览器加载这些文件，导致主题样式不完整。
+
+```nginx
+# 允许 ACME 证书验证（SSL 必需）
+location ^~ /.well-known/ {
+    allow all;
+}
+
+# 后台伪静态（必须在 / 之前）
+location /admin/ {
+    try_files $uri $uri/ /admin/index.php?$query_string;
+}
+
+# 前台伪静态
+location / {
+    try_files $uri $uri/ /index.php?$query_string;
+}
+
+# 允许 Stately 主题的编译产物被浏览器请求
+location ~ ^/tmp/.*\.(css|js)$ {
+    expires 1d;
+    access_log off;
+}
+
+# 禁止访问敏感目录（注意 tmp 的 css/js 已在上方放行）
+location ~ ^/(conf|log)/ {
+    deny all;
+}
+location ~ ^/tmp/ {
+    deny all;
+}
+
+# 隐藏点文件
+location ~ /\. {
+    deny all;
+}
+```
+
+> **注意**：如果缺少 `location /admin/` 规则，后台的伪静态地址（如插件安装）会走错路由。
+> 如果缺少 `location ~ ^/tmp/.*\.(css|js)$` 规则，Stately 主题的核心样式和脚本会被拦截返回 403。
 
 ## 4. 首次启用建议（降低冲突风险）
 

--- a/plugin/abs_theme_stately/inc/kumquat_utility.func.php
+++ b/plugin/abs_theme_stately/inc/kumquat_utility.func.php
@@ -75,6 +75,7 @@ function hexrgba($color, $opacity = false) {
  */
 
 function hexToHsl($hex) {
+    $hex = ltrim((string)$hex, '#');
     $red = hexdec(substr($hex, 0, 2)) / 255;
     $green = hexdec(substr($hex, 2, 2)) / 255;
     $blue = hexdec(substr($hex, 4, 2)) / 255;
@@ -86,7 +87,7 @@ function hexToHsl($hex) {
     if ($delta === 0) {
         $hue = 0;
     } elseif ($cmax === $red) {
-        $hue = (($green - $blue) / $delta) % 6;
+        $hue = fmod(($green - $blue) / $delta, 6);
     } elseif ($cmax === $green) {
         $hue = ($blue - $red) / $delta + 2;
     } else {
@@ -98,8 +99,10 @@ function hexToHsl($hex) {
         $hue += 360;
     }
 
-    $lightness = (($cmax + $cmin) / 2) * 100;
-    $saturation = $delta === 0 ? 0 : ($delta / (1 - abs(2 * $lightness - 1))) * 100;
+    $lightness = ($cmax + $cmin) / 2;
+    $saturation = $delta === 0 ? 0 : ($delta / (1 - abs(2 * $lightness - 1)));
+    $lightness *= 100;
+    $saturation *= 100;
     if ($saturation < 0) {
         $saturation += 100;
     }


### PR DESCRIPTION
fix: PHP 8.2 compat for hexToHsl and nginx deploy guide for Stately

Issues found during actual VPS deployment (CentOS 7 + BT panel + PHP 8.2):

1. kumquat_utility.func.php hexToHsl():
   - Did not strip leading '#' from hex input, causing hexdec()
     to receive invalid characters (PHP 8.2 Deprecated warning)
   - Used % 6 (integer modulo) on a float, which is deprecated
     in PHP 8.2; replaced with fmod()
   - Saturation formula used $lightness already scaled to 0-100
     instead of 0-1, producing incorrect HSL output

2. docs/TEST_VPS_DEPLOY.md:
   - Added complete Nginx location block reference including:
     - /admin/ rewrite (without it, admin pseudo-static URLs
       fall through to the frontend router)
     - /tmp/*.css|js passthrough (Stately compiles CSS/JS bundles
       into tmp/; a blanket deny on /tmp/ blocks them, returning
       403 and breaking the entire theme)
     - /.well-known/ allow for ACME/Let's Encrypt validation
     - Separate deny rules for /conf/, /log/, and remaining /tmp/


## Summary
- Fix \hexToHsl()\ in \kumquat_utility.func.php\ for PHP 8.2 (strip \#\, use \mod()\, fix saturation formula)
- Add Nginx configuration reference to \docs/TEST_VPS_DEPLOY.md\ covering admin rewrite, tmp CSS/JS passthrough, ACME challenge, and security deny rules

## Test plan
- [ ] Deploy test package on a fresh CentOS 7 + BT panel + PHP 8.2 server
- [ ] Verify Stately theme colors render correctly (no CSS 403)
- [ ] Verify admin panel pseudo-static routes work
- [ ] Verify Let's Encrypt certificate issuance succeeds